### PR TITLE
Update Privacy Policy Guide message to replace deprecated classes

### DIFF
--- a/includes/admin/class-alnp-privacy.php
+++ b/includes/admin/class-alnp-privacy.php
@@ -50,8 +50,8 @@ if ( ! class_exists( 'ALNP_Privacy' ) ) {
 		 */
 		protected static function get_privacy_policy_guide_message() {
 			$content = '
-				<div contenteditable="false">' .
-					'<p class="wp-policy-help">' .
+				<div class="wp-suggested-text">' .
+					'<p class="privacy-policy-tutorial">' .
 						sprintf( __( '%s does not collect, store or share any personal data.', 'auto-load-next-post' ), esc_html__( 'Auto Load Next Post', 'auto-load-next-post' ) ) .
 					'</p>' .
 				'</div>';


### PR DESCRIPTION
Update Suggested Privacy Policy text to utilize privacy-policy-tutorial css class instead of wp-policy-help as it was deprecated. Also wrap the contents in the wp-suggested-text div to style the section to match WordPress. This follows from [WPCoreTrac#49282](https://core.trac.wordpress.org/ticket/49282) and although back-compat is being introduced in WP5.4 as of [WPChangeset#47112](https://core.trac.wordpress.org/changeset/47112) this change will better support users of WP5.1-5.4

This also removes the wrapping <div contenteditable="false"> as it's now unnecessary. As long as the content uses the proper privacy-policy-tutorial class then the WP Privacy Policy Guide section copy action will avoid copying that content. The contenteditable divs were there originally when the contents was fully copied due to not using the appropriate class, and when originally the entire guide would be dumped into the WYSIWYG editor with wp-policy-help sections being highlighted.